### PR TITLE
Adding untested support for importing mkcd files

### DIFF
--- a/src/components/AssetList.tsx
+++ b/src/components/AssetList.tsx
@@ -344,6 +344,7 @@ class AssetList extends React.Component<AssetListProps, AssetListState> {
                                     this._items.push({ name: el.qualifiedName || this.getValidAssetName(DEFAULT_NAME), jres: el })
                                 } )
                                 this.setState({items: this._items})
+                                this.hideAlert();
 
                             }
                             catch (e) {

--- a/src/share.ts
+++ b/src/share.ts
@@ -122,6 +122,18 @@ export async function fetchMakeCodeScriptAsync(url: string) {
         }
     }
 
+    const projectImages = grabImagesFromProject(filesystem);
+
+    return {
+        meta,
+        files: filesystem,
+        projectImages: projectImages,
+        customPalette: paletteIsCustom ? palette : undefined
+    };
+}
+
+
+export function grabImagesFromProject(filesystem: {[index: string]: string}, palette = arcadePalette) {
     // Don't bother checking python and blocks files, they should all get converted to a matching ts
     // file that will also contain all image literals
     const typescriptFiles = Object.keys(filesystem).filter(filename =>
@@ -151,12 +163,7 @@ export async function fetchMakeCodeScriptAsync(url: string) {
         }
     }
 
-    return {
-        meta,
-        files: filesystem,
-        projectImages: Object.keys(seenImages).map(data => seenImages[data]),
-        customPalette: paletteIsCustom ? palette : undefined
-    };
+    return Object.keys(seenImages).map(data => seenImages[data]);
 }
 
 function grabImagesFromJRES(jresText: string, filename: string, palette = arcadePalette): JRESImage[] {


### PR DESCRIPTION
I have not tested this because for some reason the drag+drop code does not work on my local box (even for PNGs). it does work on the github io page, but for some reason the event never fires for me locally.